### PR TITLE
Feature/athn 6618 athena api custom binding for postgresql double to json double

### DIFF
--- a/jOOQ/src/main/java/org/jooq/tools/json/Yylex.java
+++ b/jOOQ/src/main/java/org/jooq/tools/json/Yylex.java
@@ -656,7 +656,27 @@ class Yylex {
                 }
                 case 44: break;
                 case 2:
-                { Long val=Long.valueOf(yytext()); return new Yytoken(Yytoken.TYPE_VALUE, val);
+                {
+                  // This is a number without a decimal point, but it could be a Double
+                  // Long range: -9223372036854775808 (len: 20) to 9223372036854775807 (len: 19)
+                  if (yytext().length() < 19) {
+                    // definitely a Long
+                    Long val = Long.valueOf(yytext());
+                    return new Yytoken(Yytoken.TYPE_VALUE, val);
+                  } else if (yytext().length() > 20) {
+                    // definitely a Double
+                    Double val=Double.valueOf(yytext());
+                    return new Yytoken(Yytoken.TYPE_VALUE, val);
+                  } else {
+                    // Could be a Long, could be a Double, let's find out
+                    try {
+                      Long val = Long.valueOf(yytext());
+                      return new Yytoken(Yytoken.TYPE_VALUE, val);
+                    } catch (NumberFormatException e) {
+                      Double val=Double.valueOf(yytext());
+                      return new Yytoken(Yytoken.TYPE_VALUE, val);
+                    }
+                  }
                 }
                 case 45: break;
                 case 18:


### PR DESCRIPTION
Handle the case where a Multipart query field has no decimal point but is larger than a Long.